### PR TITLE
add Error.$prototype.name to reconstructed Errors

### DIFF
--- a/src/RpcClient.ts
+++ b/src/RpcClient.ts
@@ -54,7 +54,7 @@ export abstract class RpcClient {
                 if (data.result.stack) {
                     error.stack = data.result.stack;
                 }
-                if(data.result.name) {
+                if (data.result.name) {
                     error.name = data.result.name;
                 }
                 callback.reject(error, data.id, state);
@@ -146,7 +146,7 @@ export class PostMessageRpcClient extends RpcClient {
                 if (data.result.stack) {
                     const error = new Error(data.result.message);
                     error.stack = data.result.stack;
-                    if(data.result.name) {
+                    if (data.result.name) {
                         error.name = data.result.name;
                     }
                     console.error(error);

--- a/src/RpcClient.ts
+++ b/src/RpcClient.ts
@@ -54,6 +54,9 @@ export abstract class RpcClient {
                 if (data.result.stack) {
                     error.stack = data.result.stack;
                 }
+                if(data.result.name) {
+                    error.name = data.result.name;
+                }
                 callback.reject(error, data.id, state);
             }
         } else {
@@ -143,6 +146,9 @@ export class PostMessageRpcClient extends RpcClient {
                 if (data.result.stack) {
                     const error = new Error(data.result.message);
                     error.stack = data.result.stack;
+                    if(data.result.name) {
+                        error.name = data.result.name;
+                    }
                     console.error(error);
                 }
 

--- a/src/State.ts
+++ b/src/State.ts
@@ -72,7 +72,7 @@ export class State {
         if (status === ResponseStatus.ERROR) {
             // serialize error objects
             result = typeof result === 'object'
-                ? { message: result.message, stack: result.stack }
+                ? { message: result.message, stack: result.stack, name: result.name }
                 : { message: result };
         }
 


### PR DESCRIPTION
Adds property name to reconstructed `Error` objects to enable grouping. 
The Keyguard already creates `Error` objects with the property while Accounts will be updated in the future to do so as well.