### PR TITLE
Remove popup timeout and memory leaks

### DIFF
--- a/src/RpcClient.ts
+++ b/src/RpcClient.ts
@@ -179,19 +179,17 @@ export class PostMessageRpcClient extends RpcClient {
 
             window.addEventListener('message', connectedListener);
 
-            let connectTimer = 0;
-            const timeoutTimer = setTimeout(() => {
-                window.removeEventListener('message', connectedListener);
-                clearTimeout(connectTimer);
-                reject(new Error('Connection timeout'));
-            }, 10 * 1000);
-
             /**
              * Send 'ping' command every 100ms, until cancelled
              */
             const tryToConnect = () => {
                 if (this._connected) {
-                    clearTimeout(timeoutTimer);
+                    return;
+                }
+
+                if (this._target.closed) {
+                    window.removeEventListener('message', connectedListener);
+                    reject(new Error('Window was closed'));
                     return;
                 }
 
@@ -201,10 +199,10 @@ export class PostMessageRpcClient extends RpcClient {
                     console.error(`postMessage failed: ${e}`);
                 }
 
-                connectTimer = window.setTimeout(tryToConnect, 100);
+                window.setTimeout(tryToConnect, 100);
             };
 
-            connectTimer = window.setTimeout(tryToConnect, 100);
+            window.setTimeout(tryToConnect, 100);
         });
     }
 }

--- a/src/RpcClient.ts
+++ b/src/RpcClient.ts
@@ -121,6 +121,14 @@ export class PostMessageRpcClient extends RpcClient {
         });
     }
 
+    public close() {
+        // Clean up old requests and disconnect. Note that until the popup get's closed by the user
+        // it's possible to connect again though by calling init.
+        window.removeEventListener('message', this._receiveListener);
+        this._cleanUp();
+        this._connected = false;
+    }
+
     private async _call(request: {command: string, args: any[], id: number, persistInUrl?: boolean}): Promise<any> {
         if (!this._connected) throw new Error('Client is not connected, call init first');
 
@@ -145,14 +153,6 @@ export class PostMessageRpcClient extends RpcClient {
 
             this._target!.postMessage(request, this._allowedOrigin);
         });
-    }
-
-    public close() {
-        // Clean up old requests and disconnect. Note that until the popup get's closed by the user
-        // it's possible to connect again though by calling init.
-        window.removeEventListener('message', this._receiveListener);
-        this._cleanUp();
-        this._connected = false;
     }
 
     private _connect() {


### PR DESCRIPTION
Addresses https://github.com/nimiq/rpc/issues/10 and https://github.com/nimiq/rpc/issues/11.

- Don't timeout during connection, instead fail if popup was closed
- remove reference to popup after it gets closed
- unbind receiveListener when popup gets closed
- clean up stored requests when not needed anymore
- avoid subsequent invocation of init when connection already established
- small linter fix