### PR TITLE
Re-activate reject-on-back

### DIFF
--- a/src/RpcServer.ts
+++ b/src/RpcServer.ts
@@ -48,6 +48,9 @@ export class RpcServer {
     }
 
     private _receiveRedirect() {
+        // Stop executing, because if this property exists the client's rejectOnBack should be triggered
+        if (history.state && history.state.rpcBackRejectionId) return;
+
         const message = UrlRpcEncoder.receiveRedirectCommand(window.location);
         if (message) {
             window.clearTimeout(this._clientTimeout);


### PR DESCRIPTION
Adds a new paramter to `RedirectRpcClient`'s `call` and `callAndSaveLocalState` methods, to individually signal if a history-back detector flag should be stored in `history.state` or not (default not).

The `rejectOnBack` method only rejects when this flag is set. Additionally, the `RpcServer` does not start a redirect detection when this flag is found (however, the client deletes the flag, so if the server is usually initialized after the client, it is in the responsibility of the app to not start the server when the client rejects).