### PR TITLE
Store params in URL fragment

### DIFF
--- a/src/JSONUtils.ts
+++ b/src/JSONUtils.ts
@@ -1,4 +1,4 @@
-import {Base64} from './base64/Base64';
+import { Base64 } from './base64/Base64';
 
 enum ExtraJSONTypes {
     UINT8_ARRAY,

--- a/src/RequestIdStorage.ts
+++ b/src/RequestIdStorage.ts
@@ -1,4 +1,4 @@
-import {JSONUtils} from './JSONUtils';
+import { JSONUtils } from './JSONUtils';
 import { ObjectType } from './ObjectType';
 
 export class RequestIdStorage {

--- a/src/RpcClient.ts
+++ b/src/RpcClient.ts
@@ -125,7 +125,6 @@ class PostMessageRpcClient extends RpcClient {
             command,
             args,
             id: RandomUtils.generateRandomId(),
-            persistInUrl: true,
         });
     }
 
@@ -158,7 +157,7 @@ class PostMessageRpcClient extends RpcClient {
         super._receive(message, false);
     }
 
-    private async _call(request: {command: string, args: any[], id: number, persistInUrl?: boolean}): Promise<any> {
+    private async _call(request: {command: string, args: any[], id: number}): Promise<any> {
         if (!this._target || this._target.closed) {
             throw new Error('Connection was closed.');
         }

--- a/src/RpcClient.ts
+++ b/src/RpcClient.ts
@@ -120,14 +120,6 @@ class PostMessageRpcClient extends RpcClient {
         });
     }
 
-    public async callAndPersist(command: string, ...args: any[]): Promise<any> {
-        return this._call({
-            command,
-            args,
-            id: RandomUtils.generateRandomId(),
-        });
-    }
-
     public close() {
         // Clean up old requests and disconnect. Note that until the popup get's closed by the user
         // it's possible to connect again though by calling init.
@@ -263,22 +255,22 @@ export class RedirectRpcClient extends RpcClient {
 
     public async init() {
         // Check for a response in the URL (also removes params)
-        const urlMessage = UrlRpcEncoder.receiveRedirectResponse(window.location);
-        if (urlMessage) {
-            this._receive(urlMessage);
+        const urlResponse = UrlRpcEncoder.receiveRedirectResponse(window.location);
+        if (urlResponse) {
+            this._receive(urlResponse);
             return;
         }
 
         // Check for a stored response referenced by a URL 'id' parameter
         const searchParams = new URLSearchParams(window.location.search);
         if (searchParams.has('id')) {
-            const response = window.sessionStorage.getItem(`response-${searchParams.get('id')}`);
-            if (response) {
-                this._receive(JSONUtils.parse(response), false);
+            const storedResponse = window.sessionStorage.getItem(`response-${searchParams.get('id')}`);
+            if (storedResponse) {
+                this._receive(JSONUtils.parse(storedResponse), false);
                 return;
             }
         }
-
+        // If there is no response in the URL or stored the user must have navigated back in history.
         this._rejectOnBack();
     }
 

--- a/src/RpcServer.ts
+++ b/src/RpcServer.ts
@@ -1,4 +1,4 @@
-import { RedirectRequest, ResponseStatus, POSTMESSAGE_RETURN_URL } from './Messages';
+import { RedirectRequest, ResponseStatus } from './Messages';
 import { JSONUtils } from './JSONUtils';
 import { State } from './State';
 import { UrlRpcEncoder } from './UrlRpcEncoder';
@@ -99,12 +99,7 @@ export class RpcServer {
             console.debug('RpcServer ACCEPT', state.data);
 
             if (persistMessage) {
-                sessionStorage.setItem(`request-${state.data.id}`, JSONUtils.stringify({
-                    data: state.data,
-                    origin: state.origin,
-                    returnURL: POSTMESSAGE_RETURN_URL,
-                    source: null,
-                }));
+                sessionStorage.setItem(`request-${state.data.id}`, JSONUtils.stringify(state.toRequestObject()));
             }
 
             const url = new URL(window.location.href);

--- a/src/RpcServer.ts
+++ b/src/RpcServer.ts
@@ -26,7 +26,6 @@ export class RpcServer {
         this._allowedOrigin = allowedOrigin;
         this._responseHandlers = new Map();
         this._responseHandlers.set('ping', () => {
-            window.clearTimeout(this._clientTimeout);
             return 'pong';
         });
         this._receiveListener = this._receive.bind(this);
@@ -53,19 +52,18 @@ export class RpcServer {
         if (history.state && history.state.rpcBackRejectionId) return;
 
         // Check for a request in the URL (also removes params)
-        const urlMessage = UrlRpcEncoder.receiveRedirectCommand(window.location);
-        if (urlMessage) {
-            this._receive(urlMessage);
+        const urlRequest = UrlRpcEncoder.receiveRedirectCommand(window.location);
+        if (urlRequest) {
+            this._receive(urlRequest);
             return;
         }
 
         // Check for a stored request referenced by a URL 'id' parameter
         const searchParams = new URLSearchParams(window.location.search);
         if (searchParams.has('id')) {
-            const request = window.sessionStorage.getItem(`request-${searchParams.get('id')}`);
-            if (request) {
-                this._receive(JSONUtils.parse(request), false);
-                return;
+            const storedRequest = window.sessionStorage.getItem(`request-${searchParams.get('id')}`);
+            if (storedRequest) {
+                this._receive(JSONUtils.parse(storedRequest), false);
             }
         }
     }

--- a/src/RpcServer.ts
+++ b/src/RpcServer.ts
@@ -61,7 +61,7 @@ export class RpcServer {
 
         // Check for a stored request referenced by a URL 'id' parameter
         const searchParams = new URLSearchParams(window.location.search);
-        if(searchParams.has('id')) {
+        if (searchParams.has('id')) {
             const request = window.sessionStorage.getItem(`request-${searchParams.get('id')}`);
             if (request) {
                 this._receive(JSONUtils.parse(request), false);

--- a/src/State.ts
+++ b/src/State.ts
@@ -33,7 +33,7 @@ export class State {
     private readonly _id: number;
     private readonly _postMessage: boolean;
     private readonly _returnURL: string | null;
-    private readonly _data: {command: string, args: any[], id: number, persistInUrl?: boolean};
+    private readonly _data: {command: string, args: any[], id: number};
     private readonly _source: MessagePort|Window|ServiceWorker|string|null;
 
     constructor(message: MessageEvent|RedirectRequest|PostMessage) {

--- a/src/State.ts
+++ b/src/State.ts
@@ -108,13 +108,12 @@ export class State {
         }
     }
 
-    public toRequestUrl(baseUrl: string) {
-        return UrlRpcEncoder.prepareRedirectInvocation(
-            baseUrl,
-            this.id,
-            this.returnURL || POSTMESSAGE_RETURN_URL,
-            this.data.command,
-            this.data.args,
-        );
+    public toRequestObject(): RedirectRequest {
+        return {
+            origin: this._origin,
+            data: this._data,
+            returnURL: this._returnURL || POSTMESSAGE_RETURN_URL,
+            source: typeof this._source === 'string' ? this._source : null,
+        };
     }
 }

--- a/src/State.ts
+++ b/src/State.ts
@@ -1,7 +1,7 @@
-import {PostMessage, RedirectRequest, ResponseStatus, POSTMESSAGE_RETURN_URL} from './Messages';
-import {UrlRpcEncoder} from './UrlRpcEncoder';
-export {ResponseStatus} from './Messages';
-import {JSONUtils} from './JSONUtils';
+import { PostMessage, RedirectRequest, ResponseStatus, POSTMESSAGE_RETURN_URL } from './Messages';
+import { UrlRpcEncoder } from './UrlRpcEncoder';
+export { ResponseStatus } from './Messages';
+import { JSONUtils } from './JSONUtils';
 
 export class State {
 

--- a/src/UrlRpcEncoder.ts
+++ b/src/UrlRpcEncoder.ts
@@ -3,7 +3,9 @@ import {JSONUtils} from './JSONUtils';
 import {State} from './State';
 
 export class UrlRpcEncoder {
-    public static receiveRedirectCommand(url: URL|Location): RedirectRequest|null {
+    public static receiveRedirectCommand(location: Location): RedirectRequest|null {
+        const url = new URL(location.href);
+
         // Need referrer for origin check
         if (!document.referrer) return null;
         const referrer = new URL(document.referrer);

--- a/src/UrlRpcEncoder.ts
+++ b/src/UrlRpcEncoder.ts
@@ -51,7 +51,7 @@ export class UrlRpcEncoder {
         } else {
             url.hash = fragment.toString();
         }
-        history.replaceState(history.state, /* title */ '', url.href);
+        history.replaceState(history.state, '', url.href);
 
         return {
             origin: referrer.origin,
@@ -94,7 +94,7 @@ export class UrlRpcEncoder {
         } else {
             url.hash = fragment.toString();
         }
-        history.replaceState(history.state, /* title */ '', url.href);
+        history.replaceState(history.state, '', url.href);
 
         return {
             origin: referrer.origin,

--- a/src/UrlRpcEncoder.ts
+++ b/src/UrlRpcEncoder.ts
@@ -1,6 +1,6 @@
-import {RedirectRequest, ResponseMessage, ResponseStatus, POSTMESSAGE_RETURN_URL} from './Messages';
-import {JSONUtils} from './JSONUtils';
-import {State} from './State';
+import { RedirectRequest, ResponseMessage, ResponseStatus, POSTMESSAGE_RETURN_URL } from './Messages';
+import { JSONUtils } from './JSONUtils';
+import { State } from './State';
 
 export class UrlRpcEncoder {
     public static receiveRedirectCommand(location: Location): RedirectRequest|null {


### PR DESCRIPTION
This combines #18 and url fragments.

The request ID is stored in the query (so it doesn't get lost when doing fragment-based navigation), but all other params are transmitted in the fragment for redirects.

Both the redirect and postMessage params are then stored in sessionstorage, referenced by the request ID in the URL to load them again on page refresh. Same for responses.