### PR TITLE
Move id to fragment, rename id in query to rpcId

### DIFF
--- a/src/RpcClient.ts
+++ b/src/RpcClient.ts
@@ -262,8 +262,10 @@ export class RedirectRpcClient extends RpcClient {
 
         // Check for a stored response referenced by a URL 'id' parameter
         const searchParams = new URLSearchParams(window.location.search);
-        if (searchParams.has('id')) {
-            const storedResponse = window.sessionStorage.getItem(`response-${searchParams.get('id')}`);
+        if (searchParams.has(UrlRpcEncoder.URL_SEARCHPARAM_NAME)) {
+            const storedResponse = window.sessionStorage.getItem(
+                `response-${searchParams.get(UrlRpcEncoder.URL_SEARCHPARAM_NAME)}`,
+            );
             if (storedResponse) {
                 this._receive(JSONUtils.parse(storedResponse), false);
                 return;

--- a/src/RpcServer.ts
+++ b/src/RpcServer.ts
@@ -60,8 +60,10 @@ export class RpcServer {
 
         // Check for a stored request referenced by a URL 'id' parameter
         const searchParams = new URLSearchParams(window.location.search);
-        if (searchParams.has('id')) {
-            const storedRequest = window.sessionStorage.getItem(`request-${searchParams.get('id')}`);
+        if (searchParams.has(UrlRpcEncoder.URL_SEARCHPARAM_NAME)) {
+            const storedRequest = window.sessionStorage.getItem(
+                `request-${searchParams.get(UrlRpcEncoder.URL_SEARCHPARAM_NAME)}`,
+            );
             if (storedRequest) {
                 this._receive(JSONUtils.parse(storedRequest), false);
             }
@@ -105,7 +107,7 @@ export class RpcServer {
             }
 
             const url = new URL(window.location.href);
-            url.searchParams.set('id', state.data.id.toString());
+            url.searchParams.set(UrlRpcEncoder.URL_SEARCHPARAM_NAME, state.data.id.toString());
             window.history.replaceState(history.state, '', url.href);
 
             // Call method


### PR DESCRIPTION
also removes the replaceState side effect from `UrlRpcEncoder._setUrlFragment`